### PR TITLE
Add fix for copying plist file when it already exists

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -19,13 +19,12 @@ end
 
 package 'mysql'
 
-ruby_block 'copy mysql plist to ~/Library/LaunchAgents' do
-  block do
-    active_mysql = Pathname.new('/usr/local/bin/mysql').realpath
-    plist_location = (active_mysql + '../../' + 'homebrew.mxcl.mysql.plist').to_s
-    destination = "#{node['sprout']['home']}/Library/LaunchAgents/homebrew.mxcl.mysql.plist"
-    system("cp #{plist_location} #{destination} && chown #{node['sprout']['user']} #{destination}") || fail("Couldn't find the plist")
-  end
+remote_file 'copy mysql plist to ~/Library/LaunchAgents' do
+  owner node['sprout']['user']
+  path "#{node['sprout']['home']}/Library/LaunchAgents/homebrew.mxcl.mysql.plist"
+  active_mysql = Pathname.new('/usr/local/bin/mysql').realpath
+  plist_location = (active_mysql + '../../' + 'homebrew.mxcl.mysql.plist').to_s
+  source "file://#{plist_location}"
 end
 
 ruby_block 'mysql_install_db' do


### PR DESCRIPTION
- On our OSX El Capitan workstation, this recipe threw an error:
  cp "some-path.plist and some-other-path.plist are identical (not copied)."
- We updated the recipe to use the more standard chef method `remote_file`
  to copy the plist file instead of shelling out to `cp`
