### PR TITLE
Accommodates blank passwords

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -54,11 +54,11 @@ ruby_block 'Checking that mysql is running' do
 end
 
 execute 'set the root password to the default' do
-  command "mysqladmin -uroot password #{PASSWORD}"
-  not_if "mysql -uroot -p#{PASSWORD} -e 'show databases'"
+  command "mysqladmin -uroot password '#{PASSWORD}'"
+  not_if "mysql -uroot --password='#{PASSWORD}' -e 'show databases'"
 end
 
 execute 'insert time zone info' do
-  command "mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/XXT/' | mysql -uroot -p#{PASSWORD} mysql"
-  not_if "mysql -uroot -p#{PASSWORD} mysql -e 'select * from time_zone_name' | grep -q UTC"
+  command "mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/XXT/' | mysql -uroot --password='#{PASSWORD}' mysql"
+  not_if "mysql -uroot --password='#{PASSWORD}' mysql -e 'select * from time_zone_name' | grep -q UTC"
 end

--- a/spec/unit/install_spec.rb
+++ b/spec/unit/install_spec.rb
@@ -13,14 +13,20 @@ describe 'sprout-mysql::install' do
     expect(runner).to install_package('mysql')
   end
 
-  it 'uses a default root password of `password`' do
+  it "uses a default root password of 'password'" do
     runner.converge(described_recipe)
-    expect(runner).to run_execute('mysqladmin -uroot password password')
+    expect(runner).to run_execute("mysqladmin -uroot password 'password'")
   end
 
   it 'uses the specified root password' do
     runner.node.set['sprout']['mysql']['root_password'] = 'custompassword'
     runner.converge(described_recipe)
-    expect(runner).to run_execute('mysqladmin -uroot password custompassword')
+    expect(runner).to run_execute("mysqladmin -uroot password 'custompassword'")
+  end
+
+  it 'uses the specified root password when the password is blank' do
+    runner.node.set['sprout']['mysql']['root_password'] = ''
+    runner.converge(described_recipe)
+    expect(runner).to run_execute("mysqladmin -uroot password ''")
   end
 end


### PR DESCRIPTION
While blank passwords aren't advisable, some of our clients insist on not having a password for their database. Restructuring the `mysql` command this way will let the soloist user specify an empty password in `soloistrc`, and still be able to install mysql via this cookbook.
